### PR TITLE
Improve byte compile warnings

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -32,7 +32,7 @@
 
 (require 'helm)
 
-(autoload 'migemo-search-pattern-get "migemo" nil t)
+(declare-function migemo-search-pattern-get "migemo")
 
 (defgroup helm-swoop nil
   "Open helm-swoop."
@@ -141,7 +141,7 @@
                 (when (< 2 (length $wd))
                   (goto-char (point-min))
                   ;; Optional require migemo.el & helm-migemo.el
-                  (if (functionp 'helm-migemo)
+                  (if (and (featurep 'migemo) (featurep 'helm-migemo))
                       (setq $wd (migemo-search-pattern-get $wd)))
 
                   (while (re-search-forward $wd nil t)


### PR DESCRIPTION
このような場合は `autoload`でなく, `declare-function`を用いるのが良いかと思います.

あと migemoを使うかどうかは, migemoと helm-migemoがロード済みで
あるかを確認した方が良いと思います. helm-migemoのソースを見たところ,
helm-migemoは migemoなしでもロードできるようなので, 両方確認する方が
良いと思います.

ご確認の程よろしくお願いします.
