### PR TITLE
Fix case when current-prefix is list

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -508,7 +508,7 @@ If $linum is number, lines are separated by $linum"
   (unless (boundp 'helm-swoop-last-query)
     (set (make-local-variable 'helm-swoop-last-query) ""))
   (setq helm-swoop-target-buffer (current-buffer))
-  (helm-swoop--set-prefix $multiline)
+  (helm-swoop--set-prefix (prefix-numeric-value $multiline))
   ;; Overlay
   (setq helm-swoop-line-overlay (make-overlay (point) (point)))
   (overlay-put helm-swoop-line-overlay


### PR DESCRIPTION
current-prefix is list such as 'C-u M-x helm-swoop'.
helm-swoop-last-prefix-number is set it, but this causes error.
helm-swoop-last-prefix-number should be integer.

I got following error when I execute `C-u M-x helm-swoop`.

```
if: Wrong type argument: number-or-marker-p, (4)
```
