### PR TITLE
Remove outdated reference to `helm-match-plugin-mode`

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -608,9 +608,6 @@ If $linum is number, lines are separated by $linum"
         (ad-activate 'helm-move--previous-line-fn)
         (add-hook 'helm-update-hook 'helm-swoop--pattern-match)
         (add-hook 'helm-after-update-hook 'helm-swoop--keep-nearest-position t)
-        (unless (and (symbolp 'helm-match-plugin-mode)
-                     (symbol-value 'helm-match-plugin-mode))
-          (helm-match-plugin-mode 1))
         (cond ($query
                (if (string-match
                     "\\(\\^\\[0\\-9\\]\\+\\.\\)\\(.*\\)" $query)
@@ -1053,9 +1050,6 @@ If $linum is number, lines are separated by $linum"
           (ad-activate 'helm-move--previous-line-fn)
           (add-hook 'helm-update-hook 'helm-swoop--pattern-match)
           (add-hook 'helm-after-update-hook 'helm-swoop--keep-nearest-position t)
-          (unless (and (symbolp 'helm-match-plugin-mode)
-                       (symbol-value 'helm-match-plugin-mode))
-            (helm-match-plugin-mode 1))
           (setq helm-swoop-line-overlay
                 (make-overlay (point) (point)))
           (overlay-put helm-swoop-line-overlay


### PR DESCRIPTION
Normal functionality seems preserved without it. I see no reason not to
delete it now. I don't think any further action to update helm-swoop is
needed either, at least as far as I can tell.