### PR TITLE
fix void-variable $buf introduced in b79c2152846c3

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -1038,9 +1038,9 @@ If $linum is number, lines are separated by $linum"
                           (lambda () (split-string (helm-swoop--get-content) "\n"))))
                      ($action
                       (or $action
-                          '(("Go to Line"
+                          `(("Go to Line"
                              . (lambda ($line)
-                                 (switch-to-buffer $buf)
+                                 (switch-to-buffer ,$buf)
                                  (helm-swoop--goto-line
                                   (when (string-match "^[0-9]+" $line)
                                     (string-to-number


### PR DESCRIPTION
There's a `void-variable` error that arises every time I attempt to actually visit the site of a match in `helm-multi-swoop-all` introduced in the commit b79c2152846c3. This is because the binding to `$buf` is not made until the lambda is evaluated, at which point there is no `$buf` in scope. This seems to resolve the issue.