### PR TITLE
defcustom for helm-fuzzy-match/search

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -133,6 +133,9 @@
  :type '(choice (const :tag "vertically"   split-window-vertically)
                 (const :tag "horizontally" split-window-horizontally))
  :group 'helm-swoop)
+(defcustom helm-swoop-use-fuzzy-match nil
+  "If t, use fuzzy matching functions as well as exact matches."
+  :group 'helm-swoop :type 'boolean)
 
 (defvar helm-swoop-split-window-function
   (lambda ($buf)
@@ -183,17 +186,19 @@
     (delq nil $map)))
 
 (defvar helm-c-source-swoop-match-functions
-  '(helm-mm-exact-match
-    helm-mm-match
-    helm-fuzzy-match
-    helm-mm-3-migemo-match))
+  (append
+   '(helm-mm-exact-match
+     helm-mm-match
+     helm-mm-3-migemo-match)
+   (when helm-swoop-use-fuzzy-match '(helm-fuzzy-match))))
 
 (defvar helm-c-source-swoop-search-functions
-  '(helm-mm-exact-search
-    helm-mm-search
-    helm-candidates-in-buffer-search-default-fn
-    helm-fuzzy-search
-    helm-mm-3-migemo-search))
+  (append
+   '(helm-mm-exact-search
+     helm-mm-search
+     helm-candidates-in-buffer-search-default-fn
+     helm-mm-3-migemo-search)
+   (when helm-swoop-use-fuzzy-match '(helm-fuzzy-search))))
 
 (defcustom helm-swoop-pre-input-function
   (lambda () (thing-at-point 'symbol))


### PR DESCRIPTION
fuzzy matching and searching as a default was introduced in commit
0ef60eba8304c98d787aa823e9303da31dd52f15. this is the opposite of the
previous behavior, which did not use fuzzy matching at all. this change
allows the user to turn on fuzzy matching and searching through a
defcustom.

If you want the default to be to allow fuzzy searching, then the default can be made `t`, but I'd prefer it be `nil` by default since I usually have a large number of buffers open and get many false results with fuzzy matching.