### PR TITLE
Let isearch exit when the input is empty

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -699,7 +699,8 @@ If $linum is number, lines are separated by $linum"
   (let (($query (if isearch-regexp
                     isearch-string
                   (regexp-quote isearch-string))))
-    (isearch-exit)
+    (let (search-nonincremental-instead)
+      (isearch-exit))
     (helm-swoop :$query $query)))
 ;; When doing isearch, hand the word over to helm-swoop
 (define-key isearch-mode-map (kbd "M-i") 'helm-swoop-from-isearch)
@@ -1296,7 +1297,8 @@ Last selected buffers will be applied to helm-multi-swoop.
   (let (($query (if isearch-regexp
                     isearch-string
                   (regexp-quote isearch-string))))
-    (isearch-exit)
+    (let (search-nonincremental-instead)
+      (isearch-exit))
     (helm-multi-swoop-all $query)))
 ;; When doing isearch, hand the word over to helm-swoop
 ;; (define-key isearch-mode-map (kbd "C-x M-i") 'helm-multi-swoop-all-from-isearch)


### PR DESCRIPTION
After typing `C-s`, if fails to enter `helm-swoop` if we immediately type `M-i` since `isearch` will fallback to nonincremental search. Setting `search-nonincremental-instead` to nil before `isearch-exit` avoids this problem.

