### PR TITLE
avoid error when moving lines with no results

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -1007,18 +1007,20 @@ If $linum is number, lines are separated by $linum"
            ($num (when (string-match "^[0-9]+" $key)
                    (string-to-number (match-string 0 $key))))
            ($source (helm-get-current-source))
-           ($buf (get-buffer (assoc-default 'name $source))))
-      ;; Synchronizing line position
-      (with-selected-window helm-swoop-synchronizing-window
-        (with-current-buffer $buf
-          (when (not (eq $buf helm-multi-swoop-move-line-action-last-buffer))
-            (set-window-buffer nil $buf)
-            (helm-swoop--pattern-match))
-          (helm-swoop--goto-line $num)
-          (helm-multi-swoop--overlay-move $buf)
-          (helm-swoop--recenter))
-        (setq helm-multi-swoop-move-line-action-last-buffer $buf))
-      (setq helm-swoop-last-line-info (cons $buf $num)))))
+           ($buf (let ((name (assoc-default 'name $source)))
+                   (when name (get-buffer name)))))
+      (when $buf
+        ;; Synchronizing line position
+        (with-selected-window helm-swoop-synchronizing-window
+          (with-current-buffer $buf
+            (when (not (eq $buf helm-multi-swoop-move-line-action-last-buffer))
+              (set-window-buffer nil $buf)
+              (helm-swoop--pattern-match))
+            (helm-swoop--goto-line $num)
+            (helm-multi-swoop--overlay-move $buf)
+            (helm-swoop--recenter))
+          (setq helm-multi-swoop-move-line-action-last-buffer $buf))
+        (setq helm-swoop-last-line-info (cons $buf $num))))))
 
 (defun helm-multi-swoop--get-marked-buffers ()
   (let ($list)


### PR DESCRIPTION
Previously, when using `helm-multi-swoop-all`, typing in a pattern which has no results, and pressing `<up>` or `<down>` it would error out at `(get-buffer nil)`. This is because it doesn't check (like `helm-swoop--move-line-action`) whether there is a match, and assumes there is. This only performs the action if there are any results.