### PR TITLE
Fix breaking change in helm-display-function

### DIFF
--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -148,8 +148,7 @@ and `helm-swoop-split-direction' settings."
     (when (one-window-p)
       (funcall helm-swoop-split-direction)))
   (other-window 1)
-  (switch-to-buffer $buf)
-  )
+  (switch-to-buffer $buf))
 
 (defcustom helm-swoop-split-window-function #'helm-swoop--split-window-default
   "Function to use as `helm-display-function'."
@@ -690,7 +689,6 @@ If $linum is number, lines are separated by $linum"
                 (or $source
                     (helm-c-source-swoop))
                 :buffer helm-swoop-buffer
-                :display-function helm-swoop-split-window-function
                 :input $query
                 :prompt helm-swoop-prompt
                 :preselect
@@ -1168,7 +1166,6 @@ If $linum is number, lines are separated by $linum"
                 (helm-completion-window-scroll-margin 5))
             (helm :sources $contents
                   :buffer helm-multi-swoop-buffer
-                  :display-function helm-swoop-split-window-function
                   :input (or $query helm-multi-swoop-query "")
                   :prompt helm-swoop-prompt
                   :candidate-number-limit

--- a/helm-swoop.el
+++ b/helm-swoop.el
@@ -140,16 +140,21 @@
   "If t, use fuzzy matching functions as well as exact matches."
   :group 'helm-swoop :type 'boolean)
 
-(defvar helm-swoop-split-window-function
-  (lambda ($buf)
-   (if helm-swoop-split-with-multiple-windows
-       (funcall helm-swoop-split-direction)
-       (when (one-window-p)
-        (funcall helm-swoop-split-direction)))
-    (other-window 1)
-    (switch-to-buffer $buf))
-  "Change the way to split window only when `helm-swoop' is calling")
+(defun helm-swoop--split-window-default ($buf &optional resume)
+  "Split window according to `helm-swoop-split-with-multiple-windows'
+and `helm-swoop-split-direction' settings."
+  (if helm-swoop-split-with-multiple-windows
+      (funcall helm-swoop-split-direction)
+    (when (one-window-p)
+      (funcall helm-swoop-split-direction)))
+  (other-window 1)
+  (switch-to-buffer $buf)
+  )
 
+(defcustom helm-swoop-split-window-function #'helm-swoop--split-window-default
+  "Function to use as `helm-display-function'."
+  :group 'helm-swoop
+  :type 'function)
 (defcustom helm-swoop-after-goto-line-action-hook nil
   "hooks run after `helm-swoop--goto-line"
   :group 'helm-swoop
@@ -685,6 +690,7 @@ If $linum is number, lines are separated by $linum"
                 (or $source
                     (helm-c-source-swoop))
                 :buffer helm-swoop-buffer
+                :display-function helm-swoop-split-window-function
                 :input $query
                 :prompt helm-swoop-prompt
                 :preselect
@@ -1162,6 +1168,7 @@ If $linum is number, lines are separated by $linum"
                 (helm-completion-window-scroll-margin 5))
             (helm :sources $contents
                   :buffer helm-multi-swoop-buffer
+                  :display-function helm-swoop-split-window-function
                   :input (or $query helm-multi-swoop-query "")
                   :prompt helm-swoop-prompt
                   :candidate-number-limit


### PR DESCRIPTION
I believe this fixes #123 

After manually declaring the `helm-swoop-pattern` variable as buffer-local, I was getting an error from `helm-display-buffer()`:
```
Wrong number of arguments: (1 . 1), 2
```

Looks like the underlying problem is due to [97020d189f](https://github.com/emacs-helm/helm/commit/97020d189f1b4e0220e6ba50532d99b1d18ad14c) in helm. The `helm-display-buffer` function now calls the `helm-display-function` with an additional optional arg (`RESUME`).

This PR changes `helm-swoop-split-window-function` into a `defcustom`, and split out the old default lambda value into the function `helm-swoop--split-window-default`.

~I'm unsure if using `defvar-local` is the right thing to do for `helm-swoop-pattern` et al, but it seems to work for me.~

edit: this fix actually works without `defvar-local`, I'll remove that commit.